### PR TITLE
Update rustdoc link

### DIFF
--- a/src/Breez-SDK.md
+++ b/src/Breez-SDK.md
@@ -2,6 +2,6 @@
 For documentation related to the Breez SDK, please see:
 * Breez SDK [repository](https://github.com/breez/breez-sdk)
 * Breez SDK [documentation](https://sdk-doc.breez.technology)
-* Breez SDK [API](https://breez.github.io/breez-sdk-rustdoc/doc/breez_sdk_core/) 
+* Breez SDK [API](https://breez.github.io/breez-sdk/breez_sdk_core/)
 
 The Breez SDK is free for developers. Community support is provided in [this telegram group](https://t.me/breezsdk). To interact directly with the Breez team, please [message us](contact@breez.technology).


### PR DESCRIPTION
TLDR: This PR adds to this repo the fix that https://github.com/breez/breez-sdk/pull/836 added to `breez-sdk`.

---

The rustdoc link points to [breez-sdk-rustdoc](https://github.com/breez/breez-sdk-rustdoc), which is an old deprecated rustdoc repo. That repo has a redirect to the correct rustdocs link: https://breez.github.io/breez-sdk/breez_sdk_core/

This PR changes the rustdoc link to the target link, so we bypass the redirect in the middle. The next step will be to remove the intermediary deprecated docs repo.
